### PR TITLE
Use relative path for BD references

### DIFF
--- a/scripts/write_project_tcl_git.tcl
+++ b/scripts/write_project_tcl_git.tcl
@@ -809,8 +809,9 @@ proc add_references { sub_design } {
       write_bd_as_proc $file
     } else {
       # Skip adding file if it's already part of the project
-      lappend l_script_data "if { \[get_files [file tail $file]\] == \"\" } {"
-      lappend l_script_data "  import_files -quiet -fileset [current_fileset -srcset] $file\n}"
+      set rel_file_path "[get_relative_file_path_for_source $file [get_script_execution_dir]]"
+      lappend l_script_data "if { \[get_files [file tail $rel_file_path]\] == \"\" } {"
+      lappend l_script_data "  import_files -quiet -fileset [current_fileset -srcset] $rel_file_path\n}"
     }
   }
 }


### PR DESCRIPTION
I noticed that write_project_tcl_git adds BD's Verilog references with full path. For example:
```TCL
# Adding sources referenced in BDs, if not already added
if { [get_files dbg_bridge.v] == "" } {
  import_files -quiet -fileset sources_1 /home/taras/dev/yo/external/core_dbg_bridge/src_v/dbg_bridge.v
}
if { [get_files dbg_bridge_fifo.v] == "" } {
  import_files -quiet -fileset sources_1 /home/taras/dev/yo/external/core_dbg_bridge/src_v/dbg_bridge_fifo.v
}
if { [get_files dbg_bridge_uart.v] == "" } {
  import_files -quiet -fileset sources_1 /home/taras/dev/yo/external/core_dbg_bridge/src_v/dbg_bridge_uart.v
}
if { [get_files dbg_bridge_wrapper.v] == "" } {
  import_files -quiet -fileset sources_1 /home/taras/dev/yo/fpga/common/rtl/dbg_bridge_wrapper.v
}
```
So I made a tiny to add_references in write_project_tcl_git.tcl and it does the following:

```TCL
# Adding sources referenced in BDs, if not already added
if { [get_files dbg_bridge.v] == "" } {
  import_files -quiet -fileset sources_1 ../../../external/core_dbg_bridge/src_v/dbg_bridge.v
}
if { [get_files dbg_bridge_fifo.v] == "" } {
  import_files -quiet -fileset sources_1 ../../../external/core_dbg_bridge/src_v/dbg_bridge_fifo.v
}
if { [get_files dbg_bridge_uart.v] == "" } {
  import_files -quiet -fileset sources_1 ../../../external/core_dbg_bridge/src_v/dbg_bridge_uart.v
}
if { [get_files dbg_bridge_wrapper.v] == "" } {
  import_files -quiet -fileset sources_1 ../../common/rtl/dbg_bridge_wrapper.v
}
```

Original post: https://github.com/barbedo/vivado-git/pull/9#issue-592573549