### PR TITLE
Remove all autogenerated MIG files from checkRequiredFiles

### DIFF
--- a/scripts/write_project_tcl_git.tcl
+++ b/scripts/write_project_tcl_git.tcl
@@ -456,6 +456,8 @@ proc wr_validate_files {} {
 
     lappend l_script_validate "  set files \[list \\"
     foreach file $l_local_files {
+      set file_no_quotes [string trim $file "\""]
+      if { [file extension $file_no_quotes] == ".prj" } { continue }
       lappend l_script_validate "   $file \\"
     }
     lappend l_script_validate "  \]"


### PR DESCRIPTION
Vivado adds auto-generated MIG project file to `checkRequiredFiles`. As the result, recreation files.

Before:
```TCL
  set status true
  set files [list \
   "/home/taras/dev/yo/fpga/self_test/vivado_project/self_test.srcs/sources_1/bd/top/ip/top_mig_7series_0_0/mig_a.prj" \
  ]
  foreach ifile $files {
    if { ![file isfile $ifile] } {
      puts " Could not find local file $ifile "
      set status false
    }
  }
```

After:
```TCL
  set status true
  set files [list \
  ]
  foreach ifile $files {
    if { ![file isfile $ifile] } {
      puts " Could not find local file $ifile "
      set status false
    }
  }
```